### PR TITLE
Add requirements to build in windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ build*/
 # Python
 __pycache__
 *.pyc
+*.pyd
 *.eggs
 *.pytest_cache
 *.egg-info

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -132,3 +132,24 @@ cc_library(
 )
     """
 )
+
+
+load("//:bazel/python/python_windows.bzl", "python_configure")
+load("//:bazel/python/python_windows.bzl", "numpy_configure")
+python_configure(name = "python_windows")
+numpy_configure(name = "numpy_windows")
+
+new_local_repository(
+    name = "vulkan_windows",
+    path = "C:/VulkanSDK/1.2.135.0",
+    build_file_content = """
+cc_library(
+    name = "vulkan",
+    srcs = ["Lib/vulkan-1.lib"],
+    hdrs = glob(["Include/**/*.h"]),
+    includes = ["Include"],
+    visibility = ["//visibility:public"]
+)
+    """
+)
+

--- a/bazel/glsl/rules.bzl
+++ b/bazel/glsl/rules.bzl
@@ -10,14 +10,14 @@ GlslInfo = provider(fields=[
 def _glsl_header_library(ctx):
 
     strip_include_prefix = ctx.attr.strip_include_prefix
-    
+
     includes = dict()
 
     # Add each header file directory to the includes
     if len(strip_include_prefix) == 0:
         for hdr in ctx.files.hdrs:
             includes[hdr.dirname] = True
-    
+
     else:
         includes[strip_include_prefix] = True
 
@@ -43,24 +43,24 @@ def _glsl_shader(ctx):
     inputs = [shader]
 
     for dep in ctx.attr.deps:
-    
+
         for inc in dep[GlslInfo].includes.to_list():
             args.add("-I", inc)
-        
+
         # add each header as an input file for the command.
         # This mounts the header into the sandbox running glslc and makes it
         # accessible to the compiler
         for hdr in dep[GlslInfo].headers.to_list():
             inputs.append(hdr)
-            
-    
+
+
     args.add("-o", spirv)
     args.add(shader.path)
 
     # cmd = "glslc -o %s %s" % (spirv.path, shader.path)
-    # cmd = "glslc $@"
     cmd = "glslc $@"
-    
+    # cmd = "C:/VulkanSDK/1.2.135.0/Bin/glslc $@"
+
     ctx.actions.run_shell(
         inputs = inputs,
         outputs = [spirv],

--- a/bazel/python/python_windows.bzl
+++ b/bazel/python/python_windows.bzl
@@ -1,0 +1,42 @@
+def _impl(repository_ctx):
+  result = repository_ctx.execute(["python", "-c", "from distutils.sysconfig import get_config_var; print(get_config_var('prefix'))"])
+  prefix = result.stdout.splitlines()[0]
+  repository_ctx.symlink(prefix, "python")
+  file_content = """
+cc_library(
+    name = "python3-lib",
+    srcs = ["python/libs/python38.lib"],
+    hdrs = glob(["python/include/*.h"]),
+    includes = ["python/include"],
+    visibility = ["//visibility:public"]
+)
+"""
+  repository_ctx.file("BUILD", file_content)
+
+python_configure = repository_rule(
+    implementation=_impl,
+    local = True,
+    environ = []
+)
+
+
+def _impl_numpy(repository_ctx):
+  result = repository_ctx.execute(["python", "-c", "from distutils.sysconfig import get_config_var; print(get_config_var('LIBDEST'))"])
+  prefix = result.stdout.splitlines()[0] + "/site-packages/numpy/core"
+  repository_ctx.symlink(prefix, "numpy")
+  file_content = """
+cc_library(
+    name = "numpy_cc_library",
+    hdrs = glob(["numpy/include/**/*.h"]),
+    strip_include_prefix = "numpy/include",
+    includes = ["numpy/include/numpy"],
+    visibility = ["//visibility:public"]
+)
+"""
+  repository_ctx.file("BUILD", file_content)
+
+numpy_configure = repository_rule(
+    implementation=_impl_numpy,
+    local = True,
+    environ = []
+)

--- a/cpp/core/BUILD.bazel
+++ b/cpp/core/BUILD.bazel
@@ -15,32 +15,75 @@ expand_template(
     ],
 )
 
+
+
+config_setting(
+    name = "on_linux",
+    constraint_values = [
+        "@platforms//os:linux",
+    ],
+)
+
+config_setting(
+    name = "on_windows",
+    constraint_values = [
+        "@platforms//os:windows",
+    ],
+)
+
 cc_library (
     name = "core_cc_library",
     srcs = glob(["src/**/*.cpp"]),
     hdrs = glob(["include/**/*.h"]) + [":core_lua_cc_library_header"],
     strip_include_prefix = "include/",
-    copts = [
-        "--std=c++17",
-        "-stdlib=libstdc++",
-    ],
+    copts = select({
+        ":on_linux": [
+            "-std=c++17",
+            "-stdlib=libstdc++",
+        ],
+        ":on_windows": [
+            "/std:c++17",
+            "/w",
+        ],
+    }),
     linkstatic = True,
-    linkopts = [
-        "-lvulkan",
-        "-lm",
-        "-ldl"
-    ],
+    linkopts = select({
+        ":on_linux": [
+            "-lvulkan",
+            "-lm",
+            "-ldl",
+        ],
+        ":on_windows": [
+        ],
+    }),
     deps = [
         "@sol//:sol_cc_library",
         "@lua//:lua_cc_library",
-    ],
+    ] + select({
+        ":on_windows": [
+            "@vulkan_windows//:vulkan",
+        ],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"]
 )
+
+
+
+test_opts = select({
+    ":on_linux": [
+        "-std=c++17",
+    ],
+    ":on_windows": [
+        "/std:c++17",
+        "/w",
+    ],
+})
 
 cc_test (
     name = "test_Base64",
     srcs = ["test/test_Base64.cpp"],
-    copts = ["--std=c++17",],
+    copts = test_opts,
     deps = [
         ":core_cc_library",
         "@catch//:catch_cc_library"
@@ -50,7 +93,7 @@ cc_test (
 cc_test (
     name = "test_BufferCopy",
     srcs = ["test/test_BufferCopy.cpp"],
-    copts = ["--std=c++17",],
+    copts = test_opts,
     deps = [
         ":core_cc_library",
         "@catch//:catch_cc_library"
@@ -60,7 +103,7 @@ cc_test (
 cc_test (
     name = "test_BufferCreation",
     srcs = ["test/test_BufferCreation.cpp"],
-    copts = ["--std=c++17",],
+    copts = test_opts,
     deps = [
         ":core_cc_library",
         "@catch//:catch_cc_library"
@@ -70,7 +113,7 @@ cc_test (
 cc_test (
     name = "test_BufferMapping",
     srcs = ["test/test_BufferMapping.cpp"],
-    copts = ["--std=c++17",],
+    copts = test_opts,
     deps = [
         ":core_cc_library",
         "@catch//:catch_cc_library"
@@ -80,7 +123,7 @@ cc_test (
 cc_test (
     name = "test_ComputeNode",
     srcs = ["test/test_ComputeNode.cpp"],
-    copts = ["--std=c++17",],
+    copts = test_opts,
     deps = [
         ":core_cc_library",
         "@catch//:catch_cc_library"
@@ -93,7 +136,7 @@ cc_test (
 cc_test (
     name = "test_ComputeNodeImage",
     srcs = ["test/test_ComputeNodeImage.cpp"],
-    copts = ["--std=c++17",],
+    copts = test_opts,
     deps = [
         ":core_cc_library",
         "@catch//:catch_cc_library"
@@ -107,7 +150,7 @@ cc_test (
 cc_test (
     name = "test_ImageCreation",
     srcs = ["test/test_ImageCreation.cpp"],
-    copts = ["--std=c++17",],
+    copts = test_opts,
     deps = [
         ":core_cc_library",
         "@catch//:catch_cc_library"
@@ -117,7 +160,7 @@ cc_test (
 cc_test (
     name = "test_ImageCopy",
     srcs = ["test/test_ImageCopy.cpp"],
-    copts = ["--std=c++17",],
+    copts = test_opts,
     deps = [
         ":core_cc_library",
         "@catch//:catch_cc_library"
@@ -127,7 +170,7 @@ cc_test (
 cc_test (
     name = "test_Interpreter",
     srcs = ["test/test_Interpreter.cpp"],
-    copts = ["--std=c++17",],
+    copts = test_opts,
     deps = [
         ":core_cc_library",
         "@catch//:catch_cc_library"
@@ -137,7 +180,7 @@ cc_test (
 cc_test (
     name = "test_MemoryFreeSpaceManager",
     srcs = ["test/test_MemoryFreeSpaceManager.cpp"],
-    copts = ["--std=c++17",],
+    copts = test_opts,
     deps = [
         ":core_cc_library",
         "@catch//:catch_cc_library"
@@ -147,7 +190,7 @@ cc_test (
 cc_test (
     name = "test_ProgramCreation",
     srcs = ["test/test_ProgramCreation.cpp"],
-    copts = ["--std=c++17",],
+    copts = test_opts,
     deps = [
         ":core_cc_library",
         "@catch//:catch_cc_library"
@@ -160,7 +203,7 @@ cc_test (
 cc_test (
     name = "test_SessionCreation",
     srcs = ["test/test_SessionCreation.cpp"],
-    copts = ["--std=c++17",],
+    copts = test_opts,
     deps = [
         ":core_cc_library",
         "@catch//:catch_cc_library"
@@ -170,7 +213,7 @@ cc_test (
 cc_test (
     name = "test_utils",
     srcs = ["test/test_utils.cpp"],
-    copts = ["--std=c++17",],
+    copts = test_opts,
     deps = [
         ":core_cc_library",
         "@catch//:catch_cc_library"
@@ -180,7 +223,7 @@ cc_test (
 cc_test (
     name = "test_VulkanDriver",
     srcs = ["test/test_VulkanDriver.cpp"],
-    copts = ["--std=c++17",],
+    copts = test_opts,
     deps = [
         ":core_cc_library",
         "@catch//:catch_cc_library"
@@ -190,7 +233,7 @@ cc_test (
 cc_test (
     name = "test_PushConstants",
     srcs = ["test/test_PushConstants.cpp"],
-    copts = ["--std=c++17",],
+    copts = test_opts,
     deps = [
         ":core_cc_library",
         "@catch//:catch_cc_library"
@@ -204,7 +247,7 @@ cc_test (
 cc_test (
     name = "test_Duration",
     srcs = ["test/test_Duration.cpp"],
-    copts = ["--std=c++17",],
+    copts = test_opts,
     deps = [
         ":core_cc_library",
         "@catch//:catch_cc_library"

--- a/cpp/core/include/lluvia/core/Buffer.h
+++ b/cpp/core/include/lluvia/core/Buffer.h
@@ -191,7 +191,7 @@ public:
     struct BufferMapDeleter{
 
         template<typename T>
-        void operator ()(__attribute__((unused)) T* ptr) const {
+        void operator ()(T* ptr) const {
             buffer->unmap();
         }
 

--- a/cpp/core/include/lluvia/core/Interpreter.h
+++ b/cpp/core/include/lluvia/core/Interpreter.h
@@ -57,7 +57,7 @@ public:
         sol::protected_function_result scriptResult = scriptFunction(std::forward<Args>(args)...);
 
         if (!scriptResult.valid()) {
-            const auto err = static_cast<sol::error>(scriptResult);
+            const sol::error err = scriptResult;
 
             ll::throwSystemError(ll::ErrorCode::InterpreterError,
                                  "error running code: " + sol::to_string(loadCode.status()) + "\n\t" + err.what());

--- a/cpp/core/include/lluvia/core/PushConstants.h
+++ b/cpp/core/include/lluvia/core/PushConstants.h
@@ -91,7 +91,7 @@ public:
 
     void pushInt32(const int32_t& d) {push(d);};
     void setInt32(const int32_t &d) { set(d); }
-    float getInt32() const { return get<int32_t>();}
+    int32_t getInt32() const { return get<int32_t>();}
 
 private:
     std::vector<uint8_t> m_data {};

--- a/cpp/core/src/Interpreter.cpp
+++ b/cpp/core/src/Interpreter.cpp
@@ -378,7 +378,7 @@ sol::load_result Interpreter::load(const std::string& code) {
 
     auto loadCode = m_lua->load(code);
     if (!loadCode.valid()) {
-        const auto err = static_cast<sol::error>(loadCode);
+        const sol::error err = loadCode;
 
         ll::throwSystemError(ll::ErrorCode::InterpreterError,
                              "error loading code: " + sol::to_string(loadCode.status()) + "\n\t" + err.what());

--- a/cpp/core/test/test_utils.cpp
+++ b/cpp/core/test/test_utils.cpp
@@ -11,7 +11,9 @@
 #include "lluvia/core.h"
 
 using memflags = vk::MemoryPropertyFlagBits;
-
+#ifdef _WIN32
+#define __attribute__()
+#endif
 
 struct binding {
 

--- a/external/lua.bzl
+++ b/external/lua.bzl
@@ -3,18 +3,33 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_binary")
 
+config_setting(
+    name = "on_linux",
+    constraint_values = [
+        "@platforms//os:linux",
+    ],
+)
+
+config_setting(
+    name = "on_windows",
+    constraint_values = [
+        "@platforms//os:windows",
+    ],
+)
+
 cc_library (
     name = "lua_cc_library",
     srcs = glob(
-        ["src/*.c"],
+        ["src/*.c", "src/*.h", "src/*.hpp"],
         exclude = ["src/lua.c", "src/luac.c"],
     ),
     hdrs = glob(["src/*.h", "src/*.hpp"]),
     strip_include_prefix = "src",
     linkstatic = True,
-    local_defines = [
-        "LUA_USE_LINUX",
-    ],
+    local_defines = select({
+        ":on_linux": ["LUA_USE_LINUX"],
+        ":on_windows": [],
+    }),
     visibility = ["//visibility:public"],
 )
 

--- a/external/sol.bzl
+++ b/external/sol.bzl
@@ -4,9 +4,15 @@ cc_library(
     name = "sol_cc_library",
     hdrs = glob(["single/include/sol/*.hpp"]),
     strip_include_prefix = "single/include/",
-    copts = [
-        "--std=c++17",
-    ],
+    copts = ({
+        ":on_linux": [
+            "--std=c++17",
+        ],
+        ":on_windows": [
+            "/std:c++17",
+            "/w",
+        ],
+    }),
     deps = [
         "@lua//:lua_cc_library",
     ],

--- a/python/setup.py
+++ b/python/setup.py
@@ -26,29 +26,37 @@ libDirs = ['../bazel-bin/cpp/core',
            os.path.join(VULKAN_SDK, 'lib')]
 
 
-libs   = ['core_cc_library',
-          'stdc++',
-          'vulkan',
-          'm',
-          'dl',
-          'lua_cc_library']
+# common libs first, then we add per platforms
+libs   = [
+    'core_cc_library',
+    'lua_cc_library',
+]
 
 cflags = ['-std=c++17',
           '-fPIC',
           '-Wno-unused-function',
           '-DSOL_ALL_SAFETIES_ON=1']
 
-cython_directives = {'embedsignature' : True,
-                     'infer_types' : True,
-                     'language_level': 2}
+if sys.platform == "linux":
+    libs += [
+        'stdc++',
+        'vulkan',
+        'm',
+        'dl',
+    ]
 
 if sys.platform == "win32":
-    libs = [
+    libs += [
         "vulkan-1",
     ]
     cflags = [
         "/std:c++17",
     ]
+
+
+cython_directives = {'embedsignature' : True,
+                     'infer_types' : True,
+                     'language_level': 2}
 
 def createExtension(name, sources):
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,7 +6,7 @@
     :license: Apache-2 license, see LICENSE for more details.
 """
 
-import os
+import os, sys
 import numpy as np
 from setuptools import setup
 from distutils.core import Extension
@@ -42,18 +42,30 @@ cython_directives = {'embedsignature' : True,
                      'infer_types' : True,
                      'language_level': 2}
 
+if sys.platform == "win32":
+    libs = [
+        "vulkan-1",
+    ]
+    cflags = [
+        "/std:c++17",
+    ]
+
 def createExtension(name, sources):
 
     global incDirs
     global libDirs
     global libs
 
+    runtimeLibDirs = libDirs
+    if sys.platform == 'win32':
+        runtimeLibDirs = []
+
     ext = Extension(name,
                     sources=sources,
                     include_dirs=incDirs,
                     library_dirs=libDirs,
                     libraries=libs,
-                    runtime_library_dirs=libDirs,
+                    runtime_library_dirs=runtimeLibDirs,
                     language='c++',
                     extra_compile_args=cflags)
 

--- a/python/src/BUILD.bazel
+++ b/python/src/BUILD.bazel
@@ -45,36 +45,68 @@ pyx_library (
     deps = [
         "//cpp/core:core_cc_library",
         "@lua//:lua_cc_library",
-        "@python_linux//:python3-lib",
-        "@numpy_linux//:numpy_cc_library"
-    ],
+    ] + select({
+        ":on_windows": [
+            "@python_windows//:python3-lib",
+            "@numpy_windows//:numpy_cc_library",
+        ],
+        ":on_linux": [
+            "@python_linux//:python3-lib",
+            "@numpy_linux//:numpy_cc_library",
+        ],
+    }),
     py_deps = [
         requirement("numpy"),
     ],
-    copts = [
-        "--std=c++17",
-        "-stdlib=libstdc++",
-        "-fwrapv",
-        "-O3",
-        "-Wall",
-        "-fno-strict-aliasing",
-        "-fPIC",
-        "-Wno-unused-function",
-        "-DSOL_ALL_SAFETIES_ON=1",
-    ],
-    linkopts = [
-        "-lvulkan",
-        "-lm",
-        "-ldl",
-        "-pthread",
-        "-shared",
-        "-Wl,-O3 -Wl,-Bsymbolic-functions -Wl,-z,relro",
-        "-g",
-        "-fstack-protector-strong",
-        "-Wformat",
-        "-Werror=format-security",
-        "-Wdate-time",
-        "-D_FORTIFY_SOURCE=2"
-    ],
+    copts = select({
+        ":on_windows":[
+            "/std:c++17",
+            "/w",
+        ],
+        ":on_linux": [
+            "--std=c++17",
+            "-stdlib=libstdc++",
+            "-fwrapv",
+            "-O3",
+            "-Wall",
+            "-fno-strict-aliasing",
+            "-fPIC",
+            "-DSOL_ALL_SAFETIES_ON=1",
+        ],
+    }),
+    linkopts = select({
+        ":on_linux": [
+            "-lvulkan",
+            "-lm",
+            "-ldl",
+            "-pthread",
+            "-shared",
+            "-Wl,-O3 -Wl,-Bsymbolic-functions -Wl,-z,relro",
+            "-g",
+            "-fstack-protector-strong",
+            "-Wformat",
+            "-Werror=format-security",
+            "-Wdate-time",
+            "-D_FORTIFY_SOURCE=2",
+        ],
+        ":on_windows": [
+        ],
+    }),
     visibility = ["//visibility:public"]
+)
+
+
+
+config_setting(
+    name = "on_linux",
+    constraint_values = [
+        "@platforms//os:linux",
+    ],
+)
+
+config_setting(
+    name = "on_windows",
+    constraint_values = [
+        "@platforms//os:windows",
+    ],
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 jinja2==2.10.3
 markupsafe==1.1.1
 numpy
+# in windows, we need to comment imageio because bazel tries to build it from source
 imageio
 pytest

--- a/samples/imagePyramid/BUILD.bazel
+++ b/samples/imagePyramid/BUILD.bazel
@@ -1,6 +1,20 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_binary")
 load("@//bazel/glsl:def.bzl", "glsl_shader")
 
+config_setting(
+    name = "on_linux",
+    constraint_values = [
+        "@platforms//os:linux",
+    ],
+)
+
+config_setting(
+    name = "on_windows",
+    constraint_values = [
+        "@platforms//os:windows",
+    ],
+)
+
 glsl_shader(
     name = "ImageDownsampleX_shader",
     shader = "glsl/imageDownsampleX.comp",
@@ -27,10 +41,15 @@ cc_library (
     srcs = [
         "src/ImagePyramid.cpp",
     ],
-    copts = [
-        "--std=c++17",
-        "-stdlib=libstdc++",
-    ],
+    copts = select({
+        ":on_linux": [
+            "--std=c++17",
+            "-stdlib=libstdc++",
+        ],
+        ":on_windows": [
+            "/std:c++17",
+        ],
+    }),
     linkopts = [
         "-lstdc++fs"
     ],
@@ -47,10 +66,15 @@ cc_binary (
     srcs = [
         "src/main.cpp"
     ],
-    copts = [
-        "--std=c++17",
-        "-stdlib=libstdc++",
-    ],
+    copts = select({
+        ":on_linux": [
+            "--std=c++17",
+            "-stdlib=libstdc++",
+        ],
+        ":on_windows": [
+            "/std:c++17",
+        ],
+    }),
     linkopts = [
         "-lstdc++fs"
     ],

--- a/samples/imagePyramid/include/ImagePyramid.h
+++ b/samples/imagePyramid/include/ImagePyramid.h
@@ -7,9 +7,9 @@
 #include <memory>
 #include <vector>
 
-#include <experimental/filesystem>
+#include <filesystem>
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 class ImagePyramid {
 

--- a/samples/imagePyramid/src/main.cpp
+++ b/samples/imagePyramid/src/main.cpp
@@ -13,9 +13,9 @@
 #include <memory>
 #include <vector>
 #include <iomanip>
-#include <experimental/filesystem>
+#include <filesystem>
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 using image_t = struct {
     int32_t width;
@@ -29,7 +29,7 @@ image_t readImage(const fs::path& filepath) {
 
     // read image data
     auto img        = image_t {};
-    stbi_uc* pixels = stbi_load(filepath.c_str(), &img.width, &img.height, &img.channels, STBI_rgb_alpha);
+    stbi_uc* pixels = stbi_load((char*)filepath.c_str(), &img.width, &img.height, &img.channels, STBI_rgb_alpha);
     img.channels    = 4; // overwrite to 4
 
     const auto imageSize = static_cast<uint64_t>(img.width * img.height * img.channels);
@@ -60,7 +60,7 @@ int main(int argc, const char** argv) {
     const auto channelType        = ll::ChannelType::Uint8;
     const auto imageSize          = image.width*image.height*image.channels*ll::getChannelTypeSize(channelType);
     const auto inputImageMemFlags = vk::MemoryPropertyFlagBits::eDeviceLocal;
-    
+
 
     auto session = std::shared_ptr<ll::Session> {ll::Session::create()};
 
@@ -100,7 +100,7 @@ int main(int argc, const char** argv) {
     imgCopyCmdBuffer->changeImageLayout(*inputImage, vk::ImageLayout::eGeneral);
     imgCopyCmdBuffer->end();
     session->run(*imgCopyCmdBuffer);
-    
+
     std::cout << "input image: [" << inputImage->getWidth() << ", " << inputImage->getHeight() << "]" << std::endl;
 
     auto imagePyramid = ImagePyramid {4};

--- a/samples/imagePyramid_lua/BUILD.bazel
+++ b/samples/imagePyramid_lua/BUILD.bazel
@@ -1,6 +1,20 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_binary")
 load("@//bazel/glsl:def.bzl", "glsl_shader")
 
+config_setting(
+    name = "on_linux",
+    constraint_values = [
+        "@platforms//os:linux",
+    ],
+)
+
+config_setting(
+    name = "on_windows",
+    constraint_values = [
+        "@platforms//os:windows",
+    ],
+)
+
 glsl_shader(
     name = "ImageDownsampleX_shader",
     shader = "glsl/ImageDownsampleX.comp",
@@ -25,10 +39,15 @@ cc_binary (
     srcs = [
         "src/main.cpp"
     ],
-    copts = [
-        "--std=c++17",
-        "-stdlib=libstdc++",
-    ],
+    copts = select({
+        ":on_linux": [
+            "--std=c++17",
+            "-stdlib=libstdc++",
+        ],
+        ":on_windows": [
+            "/std:c++17",
+        ],
+    }),
     linkopts = [
         "-lstdc++fs"
     ],

--- a/samples/imagePyramid_lua/src/main.cpp
+++ b/samples/imagePyramid_lua/src/main.cpp
@@ -6,9 +6,9 @@
 #include <cstddef>
 #include <cstdint>
 #include <string>
-#include <experimental/filesystem>
+#include <filesystem>
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 #include <vulkan/vulkan.hpp>
 
@@ -97,7 +97,7 @@ int main(int argc, char const* argv[]) {
     session->scriptFile("samples/imagePyramid_lua/lua/ImageDownsampleX.lua");
     session->scriptFile("samples/imagePyramid_lua/lua/ImageDownsampleY.lua");
     session->scriptFile("samples/imagePyramid_lua/lua/ImagePyramid.lua");
-    
+
     auto pyramidDesc = session->createContainerNodeDescriptor("ImagePyramid");
     auto pyramid = session->createContainerNode(pyramidDesc);
 
@@ -172,7 +172,7 @@ int main(int argc, char const* argv[]) {
                    std::static_pointer_cast<ll::ImageView>(pyramid->getPort(name))->getImage(),
                    outPath.string());
     }
-    
+
     std::cout << "ImagePyramid_lua: finish" << std::endl;
     return EXIT_SUCCESS;
 }

--- a/samples/opticalFlow/python/opticalFlow.py
+++ b/samples/opticalFlow/python/opticalFlow.py
@@ -36,7 +36,10 @@ def importLluvia(basePath):
     global util
 
     pythonPath = os.path.join(basePath, 'build/python/lib.linux-x86_64-3.6')
+    pythonPathWin = os.path.join(basePath, 'build/python/lib.win-amd64-3.8')
+
     sys.path.append(pythonPath)
+    sys.path.append(pythonPathWin)
 
     ll = importlib.import_module('lluvia')
     util = importlib.import_module('lluvia.util')
@@ -103,6 +106,9 @@ def main():
 
     sys.path.append(os.path.join(
         lluviaBasePath, 'build/python/lib.linux-x86_64-3.6'))
+    # for windows:
+    sys.path.append(os.path.join(
+        lluviaBasePath, 'python/src'))
 
     importLluvia(lluviaBasePath)
 


### PR DESCRIPTION
This is a bunch of changes needed to let lluvia build in windows.
there are some manual stuff that still needs to be done:
* comment imageio in requirements.txt, as bazel tries to build from source
* adjust bazel/glsl/rules to use glslc from Vulkan SDK installation

I don't know if there is some special testing to be done. I think if it builds correctly in linux, it is safe to merge.