### PR TITLE
#147 Set //conditions:default as conditions for building in Linux.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,10 +1,4 @@
-config_setting(
-    name = "linux",
-    constraint_values = [
-        "@platforms//os:linux",
-    ],
-    visibility = ["//visibility:public"],
-)
+# Linux is the default platform.
 
 config_setting(
     name = "android",

--- a/external/catch.bzl
+++ b/external/catch.bzl
@@ -5,15 +5,12 @@ cc_library(
     hdrs = ["single_include/catch2/catch.hpp"],
     strip_include_prefix = "single_include/",
     copts = select({
-        "@lluvia//:linux": [
-            "--std=c++17"
-        ],
         "@lluvia//:windows": [
-            "/std:c++17"
+            "/std:c++17",
         ],
         "//conditions:default": [
-            "--std=c++17"
-        ]
+            "--std=c++17",
+        ],
     }),
     visibility = ["//visibility:public"],
 )

--- a/external/sol.bzl
+++ b/external/sol.bzl
@@ -5,12 +5,12 @@ cc_library(
     hdrs = glob(["single/include/sol/*.hpp"]),
     strip_include_prefix = "single/include/",
     copts = ({
-        "@lluvia//:linux": [
-            "--std=c++17",
-        ],
         "@lluvia//:windows": [
             "/std:c++17",
             "/w",
+        ],
+        "//conditions:default": [
+            "--std=c++17",
         ],
     }),
     deps = [

--- a/external/stb.bzl
+++ b/external/stb.bzl
@@ -7,15 +7,12 @@ cc_library(
         "stb_image_write.h",
     ],
     copts = select({
-        "@lluvia//:linux": [
-            "--std=c++17"
-        ],
         "@lluvia//:windows": [
-            "/std:c++17"
+            "/std:c++17",
         ],
         "//conditions:default": [
-            "--std=c++17"
-        ]
+            "--std=c++17",
+        ],
     }),
     visibility = ["//visibility:public"],
 )

--- a/lluvia/bazel/cython/macros.bzl
+++ b/lluvia/bazel/cython/macros.bzl
@@ -15,7 +15,7 @@ def pyx_library(
         srcs_version = "PY2AND3",
         directives = [
             "--3str",
-            "--cplus"
+            "--cplus",
         ],
         copts = [],
         linkopts = [],
@@ -61,7 +61,6 @@ def pyx_library(
     py_init = []
 
     for src in srcs:
-
         if src.endswith("__init__.py"):
             py_init.append(src)
             py_srcs.append(src)
@@ -72,23 +71,21 @@ def pyx_library(
         else:
             pxd_srcs.append(src)
 
-
     # Invoke cython to produce the shared object libraries.
     shared_objects_linux = []
     shared_objects_windows = []
     for filename in pyx_srcs:
-
-        filename_noextension = filename[:-4] # remove .pyx
+        filename_noextension = filename[:-4]  # remove .pyx
 
         cy_compile_target = filename_noextension + "_cy_compile"
-        cy_compile (
+        cy_compile(
             name = cy_compile_target,
             pyx = filename,
             headers = pxd_srcs + py_init,
-            directives = directives
+            directives = directives,
         )
 
-        cc_binary (
+        cc_binary(
             name = filename_noextension + "_library",
             srcs = [cy_compile_target],
             deps = deps,
@@ -96,7 +93,7 @@ def pyx_library(
             testonly = testonly,
             copts = copts,
             linkopts = linkopts,
-            visibility = ["//visibility:public"]
+            visibility = ["//visibility:public"],
         )
 
         # for Windows, need to rename the extension of the cc_binary from .dll to .pyd
@@ -128,18 +125,17 @@ def pyx_library(
             srcs = [cp_input],
             outs = [cp_output_windows],
             cmd = "cp $(location {0}) $(location {1})".format(cp_input, cp_output_windows),
-            cmd_bat = "copy $(location {0}) $(location {1})".format(cp_input, cp_output_windows)
+            cmd_bat = "copy $(location {0}) $(location {1})".format(cp_input, cp_output_windows),
         )
 
         shared_objects_windows.append(shared_object_name_windows)
 
     shared_objects = select({
-            "@lluvia//:linux": shared_objects_linux,
-            "@lluvia//:windows": shared_objects_windows,
-            # TODO: MacOS
-            "//conditions:default": [],
-        })
-    
+        "@lluvia//:windows": shared_objects_windows,
+        # TODO: MacOS
+        "//conditions:default": shared_objects_linux,
+    })
+
     # Now create a py_library with these shared objects as data.
     py_library(
         name = name,
@@ -152,9 +148,9 @@ def pyx_library(
         **kwargs
     )
 
-    native.filegroup (
+    native.filegroup(
         name = name + "_files",
         srcs = py_srcs + pxd_srcs + shared_objects,
         data = shared_objects,
-        visibility = ["//visibility:public"]
+        visibility = ["//visibility:public"],
     )

--- a/lluvia/bazel/workspace.bzl
+++ b/lluvia/bazel/workspace.bzl
@@ -89,7 +89,7 @@ def lluvia_workspace():
         repo_rule = git_repository,
         name = "rules_vulkan",
         remote = "https://github.com/jadarve/rules_vulkan.git",
-        commit = "cdce9274c42b5964452c7e82193daff81d4bfe09",
+        commit = "a70c75d0fa4a7df98501efad0a31b1f2ca94de8f",
     )
 
     maybe(

--- a/lluvia/cpp/config.bzl
+++ b/lluvia/cpp/config.bzl
@@ -2,12 +2,12 @@
 """
 
 CC_TEST_COPTS = select({
-    "@lluvia//:linux": [
-      "-std=c++17",
-    ],
     "@lluvia//:windows": [
-      "/std:c++17",
-      "/w",
+        "/std:c++17",
+        "/w",
+    ],
+    "//conditions:default": [
+        "-std=c++17",
     ],
 })
 

--- a/lluvia/cpp/core/BUILD.bazel
+++ b/lluvia/cpp/core/BUILD.bazel
@@ -24,17 +24,6 @@ cc_library(
         "include/**/*.hpp",
     ]) + [":core_lua_cc_library_header"],
     copts = select({
-        "@lluvia//:linux": [
-            "-std=c++17",
-            "-stdlib=libstdc++",
-            "-Werror",
-            "-Wall",
-            "-Wextra",
-            "-Wshadow",
-            "-Wshorten-64-to-32",
-            "-Wnon-virtual-dtor",
-            "-pedantic",
-        ],
         "@lluvia//:android": [
             "-std=c++17",
             "-stdlib=libstdc++",
@@ -50,20 +39,31 @@ cc_library(
             "/std:c++17",
             "/w",
         ],
+        # Linux
+        "//conditions:default": [
+            "-std=c++17",
+            "-stdlib=libstdc++",
+            "-Werror",
+            "-Wall",
+            "-Wextra",
+            "-Wshadow",
+            "-Wshorten-64-to-32",
+            "-Wnon-virtual-dtor",
+            "-pedantic",
+        ],
     }),
     # linkstatic = True,
     linkopts = select({
-        "@lluvia//:linux": [
-            "-lvulkan",
-            "-lm",
-            "-ldl",
-        ],
         "@lluvia//:android": [
             "-lm",
             "-ldl",
         ],
         "@lluvia//:windows": [],
-        "//conditions:default": [],
+        "//conditions:default": [
+            "-lvulkan",
+            "-lm",
+            "-ldl",
+        ],
     }),
     strip_include_prefix = "include/",
     visibility = ["//visibility:public"],

--- a/lluvia/cpp/platform/test/BUILD.bazel
+++ b/lluvia/cpp/platform/test/BUILD.bazel
@@ -5,14 +5,13 @@ load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@lluvia//lluvia/bazel/expand_template:def.bzl", "expand_template")
 load("@lluvia//lluvia/cpp:config.bzl", "CC_TEST_COPTS")
 
-
 linkopts = select({
-    "@lluvia//:linux": [
+    "@lluvia//:windows": [],
+    "//conditions:default": [
         "-lvulkan",
         "-lm",
         "-ldl",
     ],
-    "@lluvia//:windows": [],
 })
 
 deps = [
@@ -25,34 +24,34 @@ deps = [
     "//conditions:default": [],
 })
 
-cc_test (
+cc_test(
     name = "test_InstanceCreation",
     srcs = ["test_InstanceCreation.cpp"],
     copts = CC_TEST_COPTS,
-    deps = deps,
     linkopts = linkopts,
+    deps = deps,
 )
 
-cc_test (
+cc_test(
     name = "test_InstanceCreationDynamicDispatch",
     srcs = ["test_InstanceCreationDynamicDispatch.cpp"],
     copts = CC_TEST_COPTS,
-    deps = deps,
     linkopts = linkopts,
+    deps = deps,
 )
 
-cc_test (
+cc_test(
     name = "test_InstanceWrapper",
     srcs = ["test_InstanceWrapper.cpp"],
     copts = CC_TEST_COPTS,
-    deps = deps,
     linkopts = linkopts,
+    deps = deps,
 )
 
-cc_test (
+cc_test(
     name = "test_DebugExtensions",
     srcs = ["test_DebugExtensions.cpp"],
     copts = CC_TEST_COPTS,
-    deps = deps,
     linkopts = linkopts,
+    deps = deps,
 )

--- a/lluvia/python/src/BUILD.bazel
+++ b/lluvia/python/src/BUILD.bazel
@@ -2,7 +2,7 @@ load("@lluvia//lluvia/bazel/cython:def.bzl", "pyx_library")
 
 package(default_visibility = ["//visibility:public"])
 
-pyx_library (
+pyx_library(
     name = "pyx_library",
     srcs = [
         "lluvia/__init__.py",
@@ -22,75 +22,47 @@ pyx_library (
         "lluvia/core/types.pxd",
         "lluvia/core/vulkan.pxd",
         "lluvia/util.py",
-    ] +
-    glob([
+    ] + glob([
         "lluvia/core/buffer/*.py",
         "lluvia/core/buffer/*.pyx",
         "lluvia/core/buffer/*.pxd",
-    ]) +
-    glob([
+    ]) + glob([
         "lluvia/core/device/*.py",
         "lluvia/core/device/*.pyx",
         "lluvia/core/device/*.pxd",
-    ]) +
-    glob([
+    ]) + glob([
         "lluvia/core/image/*.py",
         "lluvia/core/image/*.pyx",
         "lluvia/core/image/*.pxd",
-    ]) +
-    glob([
+    ]) + glob([
         "lluvia/core/memory/*.py",
         "lluvia/core/memory/*.pyx",
         "lluvia/core/memory/*.pxd",
-    ]) +
-    glob([
+    ]) + glob([
         "lluvia/core/node/*.py",
         "lluvia/core/node/*.pyx",
         "lluvia/core/node/*.pxd",
-    ]) +
-    glob([
+    ]) + glob([
         "lluvia/core/enums/*.py",
         "lluvia/core/enums/*.pyx",
         "lluvia/core/enums/*.pxd",
         "lluvia/core/impl/*.py",
         "lluvia/core/impl/*.pyx",
         "lluvia/core/impl/*.pxd",
-    ]) +
-    glob([
+    ]) + glob([
         "lluvia/nodes/**/*py",
         "lluvia/glsl/**/*py",
         "lluvia/resources/**/*py",
     ]),
-    srcs_version = "PY3",
-    imports = [
-        "."
-    ],
-    directives = [
-        "--3str",
-        "--cplus"
-    ],
-    deps = [
-        "//lluvia/cpp/core:core_cc_library",
-        "@rules_lua//cc:lua_cc_library",
-    ] + select({
-        "@lluvia//:windows": [
-            "@python_windows//:python3-lib",
-            "@numpy_windows//:numpy_cc_library",
-        ],
-        "@lluvia//:linux": [
-            "@python_linux//:python3-lib",
-            "@numpy_linux//:numpy_cc_library",
-        ],
-    }),
     copts = select({
-        "@lluvia//:windows":[
+        "@lluvia//:windows": [
             "/std:c++17",
             "/w",
             "/nologo",
             "/INCREMENTAL:NO",
             "/DLL",
         ],
-        "@lluvia//:linux": [
+        "//conditions:default": [
             "--std=c++17",
             "-stdlib=libstdc++",
             "-fwrapv",
@@ -101,8 +73,19 @@ pyx_library (
             "-DSOL_ALL_SAFETIES_ON=1",
         ],
     }),
+    directives = [
+        "--3str",
+        "--cplus",
+    ],
+    imports = [
+        ".",
+    ],
     linkopts = select({
-        "@lluvia//:linux": [
+        "@lluvia//:windows": [
+            "/MANIFESTUAC:NO",
+            "/MANIFEST:EMBED,ID=2",
+        ],
+        "//conditions:default": [
             "-lvulkan",
             "-lm",
             "-ldl",
@@ -116,11 +99,20 @@ pyx_library (
             "-Wdate-time",
             "-D_FORTIFY_SOURCE=2",
         ],
+    }),
+    srcs_version = "PY3",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//lluvia/cpp/core:core_cc_library",
+        "@rules_lua//cc:lua_cc_library",
+    ] + select({
         "@lluvia//:windows": [
-            "/MANIFESTUAC:NO",
-            "/MANIFEST:EMBED,ID=2",
+            "@python_windows//:python3-lib",
+            "@numpy_windows//:numpy_cc_library",
+        ],
+        "//conditions:default": [
+            "@python_linux//:python3-lib",
+            "@numpy_linux//:numpy_cc_library",
         ],
     }),
-    visibility = ["//visibility:public"]
 )
-

--- a/platform/BUILD.bazel
+++ b/platform/BUILD.bazel
@@ -1,18 +1,20 @@
 load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
 load("@rules_python//python:defs.bzl", "py_runtime")
-load(":values.bzl",
+load(
+    ":values.bzl",
     "python2_path_linux",
-    "python3_path_linux",
     "python2_path_windows",
-    "python3_path_windows")
+    "python3_path_linux",
+    "python3_path_windows",
+)
 
 # SEE https://github.com/bazelbuild/bazel/issues/7899
 
 py_runtime(
     name = "lluvia_py2_runtime",
     interpreter_path = select({
-        "@lluvia//:linux": python2_path_linux,
         "@lluvia//:windows": python2_path_windows,
+        "//conditions:default": python2_path_linux,
     }),
     python_version = "PY2",
 )
@@ -20,8 +22,8 @@ py_runtime(
 py_runtime(
     name = "lluvia_py3_runtime",
     interpreter_path = select({
-        "@lluvia//:linux": python3_path_linux,
         "@lluvia//:windows": python3_path_windows,
+        "//conditions:default": python3_path_linux,
     }),
     python_version = "PY3",
 )


### PR DESCRIPTION
Fixes #147 

Remove `@lluvia//:linux` config setting from the repository and use `//conditions:default` instead for build flags for Linux.

This enables building mediapipe Android Archive with newer versions of Bazel (6.1.1).